### PR TITLE
Fixing missed blocks

### DIFF
--- a/lamden/nodes/missing_blocks.py
+++ b/lamden/nodes/missing_blocks.py
@@ -1,0 +1,273 @@
+from lamden import storage
+from lamden.nodes.base import NEW_BLOCK_REORG_EVENT
+from contracting.db.encoder import convert_dict, encode
+from copy import deepcopy
+from lamden.crypto.block_validator import verify_block
+from lamden.crypto.wallet import Wallet
+from contracting.db.driver import ContractDriver
+from lamden.network import Network
+from lamden.crypto.canonical import block_hash_from_block
+from lamden.nodes.events import Event, EventWriter
+from lamden.logger.base import get_logger
+from lamden.peer import Peer
+
+from random import choice
+import os
+import json
+import asyncio
+import threading
+
+
+
+class MissingBlocksHandler:
+    def __init__(self, block_storage: storage.BlockStorage, nonce_storage: storage.NonceStorage,
+                 contract_driver: ContractDriver, network: Network, wallet: Wallet, event_writer: EventWriter,
+                 root=None):
+        if root is None:
+            root = os.path.expanduser(".lamden")
+        self.root = os.path.abspath(root)
+
+        self.current_thread = threading.current_thread()
+
+        self.missing_blocks_dir = os.path.join(self.root, "missing")
+        self._init_missing_blocks_dir()
+
+        self.block_storage = block_storage
+        self.nonce_storage = nonce_storage
+        self.contract_driver = contract_driver
+        self.network = network
+        self.event_writer = event_writer
+        self.wallet = wallet
+
+        self.log = get_logger(f'[{self.current_thread.name}][MISSING BLOCKS HANDLER]')
+
+    def _init_missing_blocks_dir(self):
+        if not os.path.exists(self.missing_blocks_dir):
+            os.makedirs(self.missing_blocks_dir)
+
+    def _read_missing_blocks_file(self):
+        missing_blocks_file_path = os.path.join(self.missing_blocks_dir, "missing_blocks.json")
+        try:
+            with open(missing_blocks_file_path, 'r') as f:
+                content = f.read()
+                return json.loads(content)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+    def _validate_missing_blocks_data(self, data) -> bool:
+        if data is None:
+            return False
+
+        if not isinstance(data, list) or not data:
+            return False
+
+        for item in data:
+            if not isinstance(item, str):
+                return False
+
+        return True
+
+    def _delete_missing_blocks_file(self):
+        missing_blocks_file_path = os.path.join(self.missing_blocks_dir, "missing_blocks.json")
+        try:
+            os.remove(missing_blocks_file_path)
+        except FileNotFoundError:
+            pass
+
+    async def _source_block_from_peers(self, block_num: int) -> dict:
+        if not int(block_num) > 0:
+            raise ValueError('cannot source genesis_block')
+
+        peer_list = self.network.get_all_connected_peers()
+        peers_vk_list = [peer.server_vk for peer in peer_list]
+
+        while len(peers_vk_list) > 0:
+            random_peer: Peer = self._get_random_catchup_peer(vk_list=peers_vk_list)
+            peer_vk = random_peer.server_vk
+
+            res = await random_peer.get_block(block_num=block_num)
+
+            try:
+                block = res['block_info']
+                block_num = block.get('number')
+
+                # If this is the genesis block then return it
+                # OR if the block is valid, return it.
+                if int(block_num) == 0 or verify_block(block):
+                    return block
+
+                raise ValueError(f'{block.get("number")} from {peer_vk}')
+
+            except Exception as err:
+                self.log.error(err)
+                self.log.error(f'[{block_num}] Could not get block {block_num} from peer {peer_vk} during missing block processing.')
+
+                peers_vk_list.remove(peer_vk)
+
+        return None
+
+    def _safe_set_state_changes_and_rewards(self, block: dict) -> None:
+        state_changes = block['processed'].get('state', [])
+        rewards = block.get('rewards', [])
+
+        block_num = block.get('number')
+
+        for s in state_changes:
+            value = s['value']
+            if type(value) is dict:
+                value = convert_dict(value)
+
+            self.contract_driver.driver.safe_set(
+                key=s['key'],
+                value=value,
+                block_num=block_num
+            )
+
+        for s in rewards:
+            value = s['value']
+            if type(value) is dict:
+                value = convert_dict(value)
+
+            self.contract_driver.driver.safe_set(
+                key=s['key'],
+                value=value,
+                block_num=block_num
+            )
+
+    def _save_nonce_information(self, block: dict) -> None:
+        payload = block['processed']['transaction']['payload']
+
+        self.nonce_storage.safe_set_nonce(
+            sender=payload['sender'],
+            processor=payload['processor'],
+            value=payload['nonce']
+        )
+
+    def _write_reorg_event(self, block: dict):
+        encoded_block = encode(block)
+        e = Event(
+            topics=[NEW_BLOCK_REORG_EVENT],
+            data=encoded_block
+        )
+        try:
+            self.event_writer.write_event(e)
+            self.log.info(f'Successfully sent {NEW_BLOCK_REORG_EVENT} event: {e.__dict__}')
+        except Exception as err:
+            self.log.error(f'Failed to write {NEW_BLOCK_REORG_EVENT} event: {err}')
+
+    def _get_random_catchup_peer(self, vk_list) -> Peer:
+        if len(vk_list) == 0:
+            return None
+
+        vk = choice(vk_list)
+        return self.network.get_peer(vk=vk)
+
+    def run(self):
+        missing_block_numbers_list = self.get_missing_blocks_list()
+
+        if len(missing_block_numbers_list) > 0:
+            self.log.warning("Processing Missing Blocks.")
+            self.process_missing_blocks(blocks=missing_block_numbers_list)
+
+            self.recalc_block_hashes(starting_block_num=missing_block_numbers_list[0])
+            self.log.warning("Finished Processing Missing Blocks.")
+
+
+    def get_missing_blocks_list(self) -> list:
+        data = self._read_missing_blocks_file()
+        is_valid = self._validate_missing_blocks_data(data)
+
+        if not is_valid:
+            self._delete_missing_blocks_file()
+            return []
+
+        self._delete_missing_blocks_file()
+
+        data.sort()
+        return data
+
+    async def process_missing_blocks(self, missing_block_numbers_list: list = None):
+        for block_num in missing_block_numbers_list:
+            block = await self._source_block_from_peers(block_num=int(block_num))
+            if block is not None:
+                self.process_block(block=block)
+
+    def process_block(self, block):
+        block_num: str = block.get('number')
+        storage_block = self.block_storage.get_block(v=block_num)
+
+        if storage_block:
+            return 'already_exists'
+
+        # Safe set the state changes (don't overwrite changes if they were set later blocks)
+        self._safe_set_state_changes_and_rewards(block=block)
+
+        # Save Nonce information
+        self._save_nonce_information(block=block)
+
+        # Store block in storage
+        self.block_storage.store_block(block=block)
+
+        self.log.info(f'Processed missing block {block_num}.')
+
+    async def recalc_block_hashes(self, starting_block_number: str):
+        self.log.warning("Starting to recalculate block hashes.")
+
+        starting_block = self.block_storage.get_block(v=starting_block_number)
+
+        # start with the block passed in
+        current_block = starting_block
+
+        while True:
+            current_block_number = current_block.get('number')
+            current_block_hash = current_block.get('hash')
+
+            next_block = self.block_storage.get_next_block(v=int(current_block_number))
+
+            if next_block is None:
+                break
+
+            next_block_number = next_block.get('number')
+            next_block_previous_hash = next_block.get('previous')
+
+            # only make changes if the previous hash is incorrect
+            if next_block_previous_hash != current_block_hash:
+                # change the hash in the next block
+                next_block['previous'] = current_block_hash
+
+                new_block_hash = block_hash_from_block(
+                    hlc_timestamp=next_block.get('hlc_timestamp'),
+                    block_number=next_block_number,
+                    previous_block_hash=next_block.get('previous')
+
+                )
+                next_block['hash'] = new_block_hash
+                # recalc the block hash including this new "previous hash"
+
+                next_block.pop('minted')
+
+                # resign the block to show we validated and minted it
+                signature = self.wallet.sign(encode(deepcopy(next_block)))
+                next_block['minted'] = {
+                    'minter': self.wallet.verifying_key,
+                    'signature': signature
+                }
+
+                # Delete the block currently in storage
+                self.block_storage.remove_block(v=next_block_number)
+
+                # Store the new corrected version
+                self.block_storage.store_block(block=next_block)
+
+                # Sent reorg event
+                self._write_reorg_event(block=next_block)
+
+                self.log.info(f'Recalculated block hash for block number {next_block_number}.')
+
+            current_block = next_block
+
+            await asyncio.sleep(0.05)
+
+        self.log.info("Done recalculating block hashes.")
+
+

--- a/lamden/nodes/missing_blocks.py
+++ b/lamden/nodes/missing_blocks.py
@@ -1,5 +1,4 @@
 from lamden import storage
-from lamden.nodes.base import NEW_BLOCK_REORG_EVENT
 from contracting.db.encoder import convert_dict, encode
 from copy import deepcopy
 from lamden.crypto.block_validator import verify_block
@@ -17,6 +16,7 @@ import json
 import asyncio
 import threading
 
+NEW_BLOCK_REORG_EVENT = 'block_reorg'
 
 
 class MissingBlocksHandler:
@@ -162,7 +162,7 @@ class MissingBlocksHandler:
         vk = choice(vk_list)
         return self.network.get_peer(vk=vk)
 
-    def run(self):
+    async def run(self):
         missing_block_numbers_list = self.get_missing_blocks_list()
 
         if len(missing_block_numbers_list) > 0:

--- a/lamden/storage.py
+++ b/lamden/storage.py
@@ -654,8 +654,7 @@ class FSHashStorageDriver:
 
         if os.path.islink(file_path):
             os.unlink(file_path)
-
-        self._remove_empty_dirs(starting_dir=dir_path)
+            self._remove_empty_dirs(starting_dir=dir_path)
 
     def get_file(self, hash_str: str) -> dict:
         dir_path = self.get_directory(hash_str)

--- a/lamden/storage.py
+++ b/lamden/storage.py
@@ -112,6 +112,28 @@ class BlockStorage:
 
         self.__write_block(block)
 
+    def remove_block(self, v=None):
+        if v is None:
+            return None
+
+        if isinstance(v, str) and hlc.is_hcl_timestamp(hlc_timestamp=v):
+            nanos = hlc.nanos_from_hlc_timestamp(hlc_timestamp=v)
+            if nanos > 0:
+                v = str(nanos)
+
+        block_num = str(v)
+        block = self.block_driver.find_block(block_num=block_num)
+
+        if block is None or self.is_genesis_block(block=block):
+            return
+
+        block_hash = block.get('hash')
+        tx_hash = block.get('processed')
+
+        self.block_driver.delete_block(block_num=block_num)
+        self.block_alias_driver.remove_symlink(hash_str=block_hash)
+        self.tx_driver.delete_file(hash_str=tx_hash)
+
 
     def get_block(self, v=None):
         if v is None:
@@ -323,6 +345,14 @@ class BlockDriver:
         # Writes a list of block dicts to storage
         raise NotImplementedError("Subclasses must implement this method.")
 
+    def delete_block(self, block_num: str) -> None:
+        # Deletes a block from storage
+        raise NotImplementedError("Subclasses must implement this method.")
+
+    def delete_blocks(self, block_list: list) -> None:
+        # Deletes a list of block numbers from storage
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def find_previous_block(self, block_num: str) -> dict:
         # This method will take a block number and return the previous block
         raise NotImplementedError("Subclasses must implement this method.")
@@ -429,6 +459,14 @@ class FSBlockDriver(BlockDriver):
 
         return None
 
+    def _remove_empty_dirs(self, starting_dir: str):
+        while pathlib.Path(starting_dir) != pathlib.Path(self.root):
+            if not os.listdir(starting_dir):
+                os.rmdir(starting_dir)
+                starting_dir = os.path.dirname(starting_dir)
+            else:
+                break
+
     def get_file_path(self, block_num: str) -> str:
         input_number = int(block_num)
         current_dirs = self._find_directories(input_number)
@@ -463,6 +501,17 @@ class FSBlockDriver(BlockDriver):
         shutil.move(src_path, dst_path)
 
         return dst_path
+
+    def delete_block(self, block_num: str) -> None:
+        file_path = self.get_file_path(block_num.zfill(64))
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+        self._remove_empty_dirs(starting_dir=os.path.dirname(file_path))
+
+    def delete_blocks(self, block_list: list) -> None:
+        for block_num in block_list:
+            self.delete_block(block_num=block_num)
 
     def find_block(self, block_num: str) -> dict:
         path_to_file = self.get_file_path(block_num=str(block_num).zfill(64))
@@ -563,6 +612,14 @@ class FSHashStorageDriver:
     def get_directory(self, hash_str: str) -> str:
         return os.path.join(self.root_dir, hash_str[:2], hash_str[2:4], hash_str[4:6])
 
+    def _remove_empty_dirs(self, starting_dir: str):
+        while pathlib.Path(starting_dir) != pathlib.Path(self.root_dir):
+            if not os.listdir(starting_dir):
+                os.rmdir(starting_dir)
+                starting_dir = os.path.dirname(starting_dir)
+            else:
+                break
+
     def write_file(self, hash_str: str, data: dict) -> None:
         dir_path = self.get_directory(hash_str)
         os.makedirs(dir_path, exist_ok=True)
@@ -570,6 +627,14 @@ class FSHashStorageDriver:
         file_path = os.path.join(dir_path, hash_str)
         with open(file_path, "w") as f:
             json.dump(data, f)
+
+    def delete_file(self, hash_str: str) -> None:
+        dir_path = self.get_directory(hash_str=hash_str)
+        file_path = os.path.join(dir_path, hash_str)
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+        self._remove_empty_dirs(starting_dir=dir_path)
 
     def write_symlink(self, hash_str: str, link_to: str) -> None:
         dir_path = self.get_directory(hash_str)
@@ -589,6 +654,8 @@ class FSHashStorageDriver:
 
         if os.path.islink(file_path):
             os.unlink(file_path)
+
+        self._remove_empty_dirs(starting_dir=dir_path)
 
     def get_file(self, hash_str: str) -> dict:
         dir_path = self.get_directory(hash_str)

--- a/tests/integration/mock/local_node_network.py
+++ b/tests/integration/mock/local_node_network.py
@@ -66,7 +66,14 @@ class LocalNodeNetwork:
 
         def __del__(self):
             if self.temp_network_dir.is_dir():
-                shutil.rmtree(self.temp_network_dir)
+                try:
+                    shutil.rmtree(self.temp_network_dir)
+                except OSError:
+                    tasks = asyncio.gather(
+                        asyncio.sleep(10)
+                    )
+                    self.loop.run_until_complete(tasks)
+                    self.__del__()
 
         @property
         def all_nodes(self) -> List[ThreadedNode]:

--- a/tests/integration/mock/mock_data_structures.py
+++ b/tests/integration/mock/mock_data_structures.py
@@ -363,6 +363,12 @@ class MockBlocks:
         return block_numbers
 
     @property
+    def block_list(self):
+        blocks = [block for block in list(self.blocks.values())]
+        blocks = sorted(blocks, key=lambda x: int(x['number']))
+        return blocks
+
+    @property
     def latest_block_num(self):
         k = list(self.blocks.keys())
         k.sort()

--- a/tests/unit/test_missing_blocks_handler.py
+++ b/tests/unit/test_missing_blocks_handler.py
@@ -1,0 +1,560 @@
+from unittest import TestCase
+from lamden.storage import BlockStorage, NonceStorage, LATEST_BLOCK_HASH_KEY, LATEST_BLOCK_HEIGHT_KEY
+from lamden.crypto.wallet import Wallet
+from contracting.db.driver import ContractDriver, FSDriver
+from lamden.nodes.missing_blocks import MissingBlocksHandler
+from tests.integration.mock.mock_data_structures import MockBlocks
+from contracting.db.encoder import encode
+from lamden.nodes.events import Event, EventWriter
+
+import hashlib
+
+import os
+import shutil
+import json
+import asyncio
+from copy import deepcopy
+
+# MOCK NETWORK
+class Network:
+    def __init__(self):
+        self.peers = []
+
+    def get_highest_peer_block(self) -> int:
+        current_highest_block = 0
+
+        for peer in self.peers:
+            block_list = list(peer.blocks.keys())
+            block_list.sort()
+
+            if len(block_list) > 0:
+                latest_block_number = int(block_list[-1])
+
+            if latest_block_number > current_highest_block:
+                current_highest_block = latest_block_number
+
+        return current_highest_block
+
+    def get_all_connected_peers(self):
+        return self.peers
+
+    def add_peer(self, blocks={}):
+        self.peers.append(MockPeer(blocks=blocks))
+
+    def get_peer(self, vk: str):
+        for peer in self.peers:
+            if peer.server_vk == vk:
+                return peer
+
+    def refresh_approved_peers_in_cred_provider(self):
+        pass
+
+class MockPeer:
+    def __init__(self, blocks={}):
+        self.blocks = blocks
+
+        wallet = Wallet()
+        self.server_vk = wallet.verifying_key
+
+    def find_block(self, block_num: str) -> dict:
+        return self.blocks.get(block_num, None)
+
+    async def get_block(self, block_num: int) -> (dict, None):
+        block = self.find_block(str(block_num))
+        block = json.loads(encode(block))
+        if block is None:
+            return  {'block_info': None}
+
+        return {'block_info': block}
+
+    async def get_previous_block(self, block_num: int) -> (dict, None):
+        block_list = list(self.blocks.keys())
+        block_list.sort()
+
+        try:
+            index = block_list.index(str(block_num))
+            if index == 0:
+                return {'block_info': None}
+
+            block = self.find_block(block_list[index - 1])
+            block = json.loads(encode(block))
+            return {'block_info': block}
+        except ValueError:
+            return {'block_info': None}
+
+class TestMissingBlocksHandler(TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+        self.test_dir = os.path.abspath('./.lamden')
+        self.missing_blocks_dir = os.path.join(self.test_dir, "missing")
+        self.missing_blocks_filename = "missing_blocks.json"
+
+        self.full_filename_path = os.path.join(self.missing_blocks_dir, self.missing_blocks_filename)
+
+        self.create_directories()
+
+        self.block_storage = BlockStorage(root=self.test_dir)
+        self.state_driver = FSDriver(root=self.test_dir)
+        self.contract_driver = ContractDriver(driver=self.state_driver)
+        self.nonce_storage = NonceStorage(root=self.test_dir)
+        self.mock_network = Network()
+        self.event_writer = EventWriter(root=os.path.join(self.test_dir, 'events'))
+        self.wallet = Wallet()
+
+        self.missing_blocks_handler: MissingBlocksHandler = None
+
+    def tearDown(self):
+        try:
+            self.loop.run_until_complete(self.loop.shutdown_asyncgens())
+            self.loop.close()
+        except RuntimeError:
+            pass
+
+    def create_missing_blocks_handler(self):
+        self.missing_blocks_handler = MissingBlocksHandler(
+            block_storage=self.block_storage,
+            nonce_storage=self.nonce_storage,
+            contract_driver=self.contract_driver,
+            network=self.mock_network,
+            wallet=self.wallet,
+            event_writer=self.event_writer
+        )
+
+    def create_directories(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+        os.makedirs(self.test_dir)
+
+    def add_peers_to_network(self, amount, blocks={}):
+        blocks = dict(blocks)
+        for i in range(amount):
+            self.mock_network.add_peer(blocks=blocks)
+
+    def test_INSTANCE_init__creates_all_properties(self):
+        # if the missing blocks directory exists, remove it so we can test it gets created
+        if os.path.exists(self.missing_blocks_dir):
+            shutil.rmtree(self.missing_blocks_dir)
+
+        self.create_missing_blocks_handler()
+
+        # drivers are not None
+        self.assertIsInstance(self.missing_blocks_handler.block_storage, BlockStorage)
+        self.assertIsInstance(self.missing_blocks_handler.nonce_storage, NonceStorage)
+        self.assertIsInstance(self.missing_blocks_handler.contract_driver, ContractDriver)
+        self.assertIsInstance(self.missing_blocks_handler.network, Network)
+        self.assertIsInstance(self.missing_blocks_handler.wallet, Wallet)
+
+        # root dir is stored as passed
+        self.assertEqual(self.test_dir, self.missing_blocks_handler.root)
+
+        # missing blocks directory is defined as a child of root
+        self.assertEqual(self.missing_blocks_dir, self.missing_blocks_handler.missing_blocks_dir)
+
+    def test_INSTANCE_init__creates_directory_if_it_does_not_exist(self):
+        # if the missing blocks directory exists, remove it so we can test it gets created
+        if os.path.exists(self.missing_blocks_dir):
+            shutil.rmtree(self.missing_blocks_dir)
+
+        self.create_missing_blocks_handler()
+
+        self.assertTrue(os.path.exists(self.test_dir))
+
+    def test_INSTANCE_init__does_not_error_if_directory_already_exists(self):
+        # if the missing blocks directory exists, remove it so we can test it gets created
+        if os.path.exists(self.missing_blocks_dir):
+            shutil.rmtree(self.missing_blocks_dir)
+
+        os.makedirs(self.missing_blocks_dir)
+
+        # Assert dir exists
+        self.assertTrue(os.path.exists(self.test_dir))
+
+        # Should not fail
+        try:
+            self.create_missing_blocks_handler()
+        except FileExistsError:
+            self.fail("This should not create an exception.")
+
+
+    def test_PRIVATE_METHOD_read_missing_blocks_file__returns_json_decoded_data_is_list(self):
+        self.create_missing_blocks_handler()
+
+        data = ["1682939321560636160", "8520679865965181957", "2156250479259241801"]
+
+        # Open a file for writing
+        with open(self.full_filename_path, "w") as outfile:
+            # Write the Python dictionary as a JSON string to the file
+            json.dump(data, outfile)
+
+        missing_blocks = self.missing_blocks_handler._read_missing_blocks_file()
+        self.assertIsNotNone(missing_blocks)
+        self.assertIsInstance(missing_blocks, list)
+        self.assertEqual(3, len(missing_blocks))
+
+    def test_PRIVATE_METHOD_read_missing_blocks_file__returns_None_if_not_exists(self):
+        self.create_missing_blocks_handler()
+
+        self.assertFalse(os.path.exists(self.full_filename_path))
+        missing_blocks = self.missing_blocks_handler._read_missing_blocks_file()
+
+        self.assertIsNone(missing_blocks)
+
+    def test_PRIVATE_METHOD_read_missing_blocks_file__returns_None_if_not_json(self):
+        self.create_missing_blocks_handler()
+
+        data = "1682939321560636160, 8520679865965181957, 2156250479259241801"
+
+        # Open a file for writing
+        with open(self.full_filename_path, "w") as outfile:
+            # Write the Python dictionary as a JSON string to the file
+            outfile.write(data)
+
+        self.assertTrue(os.path.exists(self.full_filename_path))
+
+        missing_blocks = self.missing_blocks_handler._read_missing_blocks_file()
+
+        self.assertIsNone(missing_blocks)
+
+    def test_PRIVATE_METHOD_validate_missing_blocks_data__returns_FALSE_if_data_None(self):
+        self.create_missing_blocks_handler()
+
+        is_valid = self.missing_blocks_handler._validate_missing_blocks_data(data=None)
+
+        self.assertFalse(is_valid)
+
+    def test_PRIVATE_METHOD_validate_missing_blocks_data__returns_FALSE_if_data_not_list(self):
+        self.create_missing_blocks_handler()
+
+        is_valid = self.missing_blocks_handler._validate_missing_blocks_data(data={})
+
+        self.assertFalse(is_valid)
+
+    def test_PRIVATE_METHOD_validate_missing_blocks_data__returns_FALSE_if_data_is_list_not_string(self):
+        self.create_missing_blocks_handler()
+
+        is_valid = self.missing_blocks_handler._validate_missing_blocks_data(
+            data=[
+                1682939321560636160,
+                "8520679865965181957",
+                2156250479259241801
+            ])
+
+        self.assertFalse(is_valid)
+
+    def test_PRIVATE_METHOD_validate_missing_blocks_data__returns_TRUE_if_data_is_list_of_strings(self):
+        self.create_missing_blocks_handler()
+
+        is_valid = self.missing_blocks_handler._validate_missing_blocks_data(
+            data=[
+                "1682939321560636160",
+                "8520679865965181957",
+                "2156250479259241801"
+            ])
+
+        self.assertTrue(is_valid)
+
+    def test_PRIVATE_METHOD_delete_missing_blocks_file__deletes_file_if_exists(self):
+        self.create_missing_blocks_handler()
+
+        data = ["1682939321560636160", "8520679865965181957", "2156250479259241801"]
+
+        # Open a file for writing
+        with open(self.full_filename_path, "w") as outfile:
+            # Write the Python dictionary as a JSON string to the file
+            json.dump(data, outfile)
+
+        # assert the file does exist
+        self.assertTrue(os.path.exists(self.full_filename_path))
+
+        self.missing_blocks_handler._delete_missing_blocks_file()
+
+        # assert the file was deleted
+        self.assertFalse(os.path.exists(self.full_filename_path))
+
+    def test_PRIVATE_METHOD_delete_missing_blocks_file__does_not_error_if_file_not_exist(self):
+        self.create_missing_blocks_handler()
+
+        # assert the file does NOT exist
+        self.assertFalse(os.path.exists(self.full_filename_path))
+
+        try:
+            self.missing_blocks_handler._delete_missing_blocks_file()
+        except FileNotFoundError:
+            self.fail("This should not create an exception.")
+
+    def test_METHOD_get_missing_blocks_list__gets_empty_list_if_no_file(self):
+        self.create_missing_blocks_handler()
+
+        missing_blocks = self.missing_blocks_handler.get_missing_blocks_list()
+
+        self.assertIsInstance(missing_blocks, list)
+        self.assertEqual(0, len(missing_blocks))
+
+    def test_METHOD_get_missing_blocks_list__returns_file_content_and_removes_file(self):
+        self.create_missing_blocks_handler()
+
+        data = ["1682939321560636160", "8520679865965181957", "2156250479259241801"]
+
+        # Open a file for writing
+        with open(self.full_filename_path, "w") as outfile:
+            # Write the Python dictionary as a JSON string to the file
+            json.dump(data, outfile)
+
+        missing_blocks = self.missing_blocks_handler.get_missing_blocks_list()
+
+        # returned list of blocks
+        self.assertIsInstance(missing_blocks, list)
+        self.assertEqual(3, len(missing_blocks))
+
+        # deleted file afterwards
+        self.assertFalse(os.path.exists(self.full_filename_path))
+
+    def test_METHOD_process_block__returns_if_block_already_exists(self):
+        self.create_missing_blocks_handler()
+
+        mock_blocks = MockBlocks(num_of_blocks=2)
+
+        for block in mock_blocks.block_list:
+            self.missing_blocks_handler.block_storage.store_block(block=block)
+
+        result = self.missing_blocks_handler.process_block(block=mock_blocks.latest_block)
+
+        self.assertEqual('already_exists', result)
+
+    def test_METHOD_process_block__processes_block_state_and_nonce_and_saved_in_storage(self):
+        expected_jeff_bal = '456'
+        expected_stu_bal = '789'
+        expected_testing_val = True
+        expected_nonce = 100
+        block_number = '1682939321560636160'
+        block_hash = 'fcf68695ed53d23939d5f82198cc61d7fbf20837f69c16b963f1dc9e0162a5c2'
+        tx_hash = 'ffe2f8ef7664c12804739a5a4b8ede34aa61a99111eae760c5a114e26774711c'
+
+        block = {
+            'number': block_number,
+            'hash': block_hash,
+            'processed': {
+                'hash': tx_hash,
+                'transaction': {
+                    'payload':{
+                        'nonce': expected_nonce,
+                        'processor': 'jeff',
+                        'sender': 'stu'
+                    }
+                },
+                'state': [
+                    {'key': 'currency.balances:jeff', 'value': {'__fixed__': '123'}},
+                    {'key': 'missedblock.testing', 'value': expected_testing_val},
+                ]
+            },
+            'rewards': [
+                {'key': 'currency.balances:jeff', 'value': {'__fixed__': expected_jeff_bal}},
+                {'key': 'currency.balances:stu', 'value': {'__fixed__': expected_stu_bal}}
+            ]
+        }
+
+        self.create_missing_blocks_handler()
+
+        self.missing_blocks_handler.process_block(block=block)
+
+        # Saved State
+        jeff_bal = self.contract_driver.driver.get('currency.balances:jeff')
+        stu_bal = self.contract_driver.driver.get('currency.balances:stu')
+        testing_val = self.contract_driver.driver.get('missedblock.testing')
+
+        self.assertEqual(expected_jeff_bal, str(jeff_bal))
+        self.assertEqual(expected_stu_bal, str(stu_bal))
+        self.assertEqual(expected_testing_val, testing_val)
+
+        # Saved Nonce
+        nonce = self.nonce_storage.get_nonce('stu', 'jeff')
+        self.assertEqual(expected_nonce, nonce)
+
+        # Saved Block
+        saved_block = self.block_storage.get_block(v=int(block_number))
+
+        self.assertIsNotNone(saved_block)
+        self.assertDictEqual(block, saved_block)
+
+
+    def test_METHOD_process_block__adds_block_to_storage_and_recalcs_hashes(self):
+        raise NotImplementedError("write test case")
+
+    def test_PRIVATE_METHOD_source_block_from_peers__can_get_block_from_peer(self):
+        mock_blocks = MockBlocks(num_of_blocks=5)
+        latest_block_number = mock_blocks.latest_block_number
+
+        self.add_peers_to_network(amount=5, blocks=mock_blocks.blocks)
+
+        self.create_missing_blocks_handler()
+
+        tasks = asyncio.gather(
+            self.missing_blocks_handler._source_block_from_peers(block_num=int(latest_block_number))
+        )
+        res = self.loop.run_until_complete(tasks)
+
+        block = res[0]
+
+        self.assertIsNotNone(block)
+        self.assertEqual(latest_block_number, block.get('number'))
+
+    def test_PRIVATE_METHOD_source_block_from_peers__returns_None_if_no_peer_has_block(self):
+        mock_blocks = MockBlocks(num_of_blocks=5)
+        missing_block_number = "8520679865965181957"
+
+        self.add_peers_to_network(amount=5, blocks=mock_blocks.blocks)
+
+        self.create_missing_blocks_handler()
+
+        tasks = asyncio.gather(
+            self.missing_blocks_handler._source_block_from_peers(block_num=int(missing_block_number))
+        )
+        res = self.loop.run_until_complete(tasks)
+
+        block = res[0]
+
+        self.assertIsNone(block)
+
+
+    def test_PRIVATE_METHOD_source_block_from_peers__raises_ValueError_on_genesis_block(self):
+        self.create_missing_blocks_handler()
+        with self.assertRaises(ValueError):
+            tasks = asyncio.gather(
+                self.missing_blocks_handler._source_block_from_peers(block_num=int(0))
+            )
+            self.loop.run_until_complete(tasks)
+
+    def test_PRIVATE_METHOD_safe_set_state_changes_and_rewards__sets_state_changes_and_reward_from_block(self):
+        self.create_missing_blocks_handler()
+
+        expected_jeff_bal = '456'
+        expected_stu_bal = '789'
+        expected_testing_val = True
+
+        block_number = '1682939321560636160'
+
+        block = {
+            'number': block_number,
+            'processed': {
+                'state': [
+                    {'key': 'currency.balances:jeff', 'value': {'__fixed__': '123'}},
+                    {'key': 'missedblock.testing', 'value': expected_testing_val},
+                ]
+            },
+            'rewards': [
+                {'key': 'currency.balances:jeff', 'value': {'__fixed__': expected_jeff_bal}},
+                {'key': 'currency.balances:stu', 'value': {'__fixed__': expected_stu_bal}}
+            ]
+        }
+
+        self.missing_blocks_handler._safe_set_state_changes_and_rewards(block=block)
+
+        jeff_bal = self.contract_driver.driver.get('currency.balances:jeff')
+        jeff_bal_block = self.contract_driver.driver.get_block('currency.balances:jeff')
+        stu_bal = self.contract_driver.driver.get('currency.balances:stu')
+        stu_bal_block = self.contract_driver.driver.get_block('currency.balances:stu')
+        testing_val = self.contract_driver.driver.get('missedblock.testing')
+        testing_val_block = self.contract_driver.driver.get_block('missedblock.testing')
+
+        self.assertEqual(expected_jeff_bal, str(jeff_bal))
+        self.assertEqual(block_number, str(jeff_bal_block))
+        self.assertEqual(expected_stu_bal, str(stu_bal))
+        self.assertEqual(block_number, str(stu_bal_block))
+        self.assertEqual(expected_testing_val, testing_val)
+        self.assertEqual(block_number, str(testing_val_block))
+
+    def test_PRIVATE_METHOD_save_nonce_information__saves_nonce_from_block(self):
+        self.create_missing_blocks_handler()
+
+        expected_nonce = 100
+        sender = 'stu'
+        processor = 'jeff'
+        block = {
+            'processed': {
+                'transaction': {
+                    'payload':{
+                        'nonce': expected_nonce,
+                        'processor': processor,
+                        'sender': sender
+                    }
+                }
+            }
+        }
+
+        self.missing_blocks_handler._save_nonce_information(block=block)
+
+        nonce = self.nonce_storage.get_nonce(sender=sender, processor=processor)
+
+        self.assertEqual(expected_nonce, nonce)
+
+    def test_METHOD_process_missing_blocks__processes_a_list_of_block_numbers(self):
+        self.create_missing_blocks_handler()
+
+        mock_blocks = MockBlocks(num_of_blocks=5)
+        self.add_peers_to_network(amount=5, blocks=mock_blocks.blocks)
+
+        missing_block_numbers_list = [block_num for block_num in mock_blocks.block_numbers_list if int(block_num) != 0]
+
+        tasks = asyncio.gather(
+            self.missing_blocks_handler.process_missing_blocks(missing_block_numbers_list=missing_block_numbers_list)
+        )
+        self.loop.run_until_complete(tasks)
+
+        for block_number in missing_block_numbers_list:
+            block = self.missing_blocks_handler.block_storage.get_block(v=int(block_number))
+            self.assertIsNotNone(block)
+
+    def test_METHOD_recalc_block_hashes__fixes_hashes_in_future_blocks(self):
+        mock_blocks = MockBlocks(num_of_blocks=5)
+        self.wallet = mock_blocks.masternode_wallet
+
+        self.create_missing_blocks_handler()
+
+
+        block_list = [deepcopy(block) for block in mock_blocks.block_list if int(block.get('number')) != 0]
+        proper_block_list = [deepcopy(block) for block in mock_blocks.block_list if int(block.get('number')) != 0]
+
+        # mess up the block hashes so we can see recalc fix them.
+        for index, block in enumerate(block_list):
+            # don't mess with the first block becausae we're going to use it as our correct "missing" block
+            if index == 0:
+                continue
+
+            # compute an incorrect block hash, can be anything
+            h = hashlib.sha3_256()
+            h.update(f'testing_{index}'.encode())
+            hash = h.hexdigest()
+            block['hash'] = hash
+
+
+            # if this is the second block we want to mess up the previous hash because it shouldn't match index 0 anymore
+            if index == 1:
+                h = hashlib.sha3_256()
+                h.update('previous'.encode())
+                block['previous'] = h.hexdigest()
+            else:
+                # for every other block make the previous block's previous hash value the value of the block's hash
+                block['previous'] = block_list[index - 1]['hash']
+
+        # add all the blocks into storage, bad hashes and all
+        for block in block_list:
+            self.missing_blocks_handler.process_block(block)
+
+        # start at index 0 which is mocked as the "missing block" we just added into storage
+        starting_block_number = block_list[0].get('number')
+        # run recalc block hashes
+        tasks = asyncio.gather(
+            self.missing_blocks_handler.recalc_block_hashes(starting_block_number=starting_block_number)
+        )
+        self.loop.run_until_complete(tasks)
+
+        # make sure recalc block hashes made the hashes correct again
+        for block in proper_block_list:
+            block_num = block.get('number')
+            stored_block = self.missing_blocks_handler.block_storage.get_block(v=int(block_num))
+            self.assertEqual(block.get('hash'), stored_block.get('hash'))
+            self.assertEqual(block.get('previous'), stored_block.get('previous'))
+            self.assertDictEqual(block.get('minted'), stored_block.get('minted'))


### PR DESCRIPTION
Node can now handle and process missing blocks by getting them from the rest of the network and fixing its block hashes on all future blocks.

- A "missing_blocks.json" file can be created and the node will detect and process it.  It will get any blocks in the file from the network and process them.
- For node running an endpoint has been created on the webserver to allow them to report missing blocks and have the file created automatically.