### PR TITLE
no longer required to connect to all peers on join

### DIFF
--- a/lamden/network.py
+++ b/lamden/network.py
@@ -319,7 +319,8 @@ class Network:
             socket_ports=self.socket_ports,
             connected_callback=self.connected_to_peer_callback,
             ctx=self.ctx,
-            local=self.local
+            local=self.local,
+            remove_peer_callback=self.remove_peer
         )
 
     def add_service(self, name: str, processor: Processor) -> None:
@@ -344,7 +345,8 @@ class Network:
         return list(filter(lambda peer: peer.connected, self.peer_list))
 
     def delete_peer(self, peer_vk: str) -> None:
-        self.peers.pop(peer_vk)
+
+        self.peers.pop(peer_vk, None)
 
     def get_peer_by_ip(self, ip: str) -> [Peer, None]:
         for peer in self.peers.values():
@@ -455,7 +457,7 @@ class Network:
     async def connected_to_all_peers(self) -> bool:
         self.log('info', f'Establishing connection with {self.num_of_peers()} peers...')
 
-        while (self.num_of_peers_connected() < self.num_of_peers()):
+        while self.num_of_peers_connected() < self.num_of_peers():
             if self.stopping:
                 self.log('warning', f'Aborting Connecting to all peers, network shutting down.')
                 return


### PR DESCRIPTION
# Network Join Issue and Solution

**Problem**

During the "join" process, a node retrieves a network map from a trusted bootnode specified in the `LAMDEN_BOOTNODES` environment variable. The node then attempts to connect with all nodes in the network map, and it won't complete the state update until successful connections have been established with all nodes.

An issue arises when a node in the network map is unreachable, such as in the recent case where @Altfinder's node had its ports closed. This prevents new nodes from joining the network, as they get stuck trying to connect to the unreachable node.

**Solution**

A change has been implemented to time out connection attempts after 2 minutes (120 seconds). If a node cannot establish a connection within this timeframe, it will continue the join process and drop the unreachable peers from the network map. When those nodes come back online the node will connect to them through the regular connection gossip layer.