### PR TITLE
hardcode catchup peers for now

### DIFF
--- a/lamden/cli/cmd.py
+++ b/lamden/cli/cmd.py
@@ -153,7 +153,8 @@ def join_network(args):
         join=True,
         metering=True,
         private_network=get_private_network_ip(),
-        genesis_block=genesis_block
+        genesis_block=genesis_block,
+        hardcoded_peers=True
     )
 
     loop = asyncio.get_event_loop()

--- a/lamden/nodes/base.py
+++ b/lamden/nodes/base.py
@@ -60,7 +60,7 @@ class Node:
                  driver=None, delay=None, client=None, debug=True, testing=False,
                  consensus_percent=None, nonces=None, genesis_block=None, metering=False,
                  tx_queue=None, socket_ports=None, reconnect_attempts=5, join=False, event_writer=None,
-                 private_network=False):
+                 private_network=False, hardcoded_peers=False):
 
         self.main_processing_queue = None
         self.validation_queue = None
@@ -190,7 +190,8 @@ class Node:
             network=self.network,
             contract_driver=self.driver,
             block_storage=self.blocks,
-            nonce_storage=self.nonces
+            nonce_storage=self.nonces,
+            hardcoded_peers=hardcoded_peers
         )
 
         self.missing_blocks_handler: MissingBlocksHandler = MissingBlocksHandler(

--- a/lamden/nodes/catchup.py
+++ b/lamden/nodes/catchup.py
@@ -15,7 +15,7 @@ from random import choice
 
 class CatchupHandler:
     def __init__(self, network: Network, contract_driver: ContractDriver, block_storage: storage.BlockStorage,
-                 nonce_storage: storage.NonceStorage):
+                 nonce_storage: storage.NonceStorage, hardcoded_peers: bool = False):
         self.current_thread = threading.current_thread()
 
         self.network = network
@@ -23,7 +23,17 @@ class CatchupHandler:
         self.contract_driver = contract_driver
         self.nonce_storage = nonce_storage
 
+        self.hardcoded_peers = hardcoded_peers
+
         self.catchup_peers = []
+        self.valid_peers = [
+            "11185fe3c6e68d11f89929e2f531de3fb640771de1aee32c606c30c70b6600d2",
+            "a04b5891ef8cd27095373a4f75b899ec2bc0883c02e506a6a5b55b491998cc3f",
+            "b09493df6c18d17cc883ebce54fcb1f5afbd507533417fe32c006009a9c3c4a",
+            "ffd7182fcfd0d84ca68845fb11bafad11abca2f9aca8754a6d9cad7baa39d28b",
+            "9d2dbfcc8cd20c8e41b24db367f215e4ac527dc6a2a0acdb4b6008d13d043ef8",
+            "e79133b02cd2a84e2ce5d24b2f44433f61f0db7e10acedfc241e94dff06f710a"
+        ]
 
         self.log = get_logger(f'[{self.current_thread.name}][CATCHUP HANDLER]')
 
@@ -36,6 +46,9 @@ class CatchupHandler:
         self.log.info('Running catchup.')
 
         self.catchup_peers = self.network.get_all_connected_peers()
+
+        if self.hardcoded_peers:
+            self.catchup_peers = [peer for peer in self.catchup_peers if peer.server_vk in self.valid_peers]
 
         if len(self.catchup_peers) == 0:
             #raise ValueError(f'No peers available for catchup!')

--- a/tests/integration/test_node_join.py
+++ b/tests/integration/test_node_join.py
@@ -232,6 +232,12 @@ class TestJoin(TestCase):
         while not self.network.all_nodes_started:
             loop.run_until_complete(asyncio.sleep(1))
 
+    def tearDown(self):
+        task = asyncio.ensure_future(self.network.stop_all_nodes())
+        loop = asyncio.get_event_loop()
+        while not task.done():
+            loop.run_until_complete(asyncio.sleep(0.1))
+
     def await_async_process(self, process, *args, **kwargs):
         tasks = asyncio.gather(
             process(*args, **kwargs)


### PR DESCRIPTION
# Catchup Issue and Solutions

**Problem**

In the current implementation, "catchup" pulls the "previous_block" from randomly sourced nodes. This introduces a potential problem: if there are nodes in the network that do not have all the blocks, they may supply an incorrect block.

**Temporary Solution**

As a workaround, we can hardcode the nodes that we know have all the blocks. This ensures that the "previous_block" is always pulled from a reliable source.

**Future Solution**

A more robust solution would be to utilize the "previous" hash value in the block we have to validate the block we receive. If the received block does not match, we can try a different node. This approach ensures we are always getting the correct "previous" block, regardless of the node's completeness.
